### PR TITLE
Use npm scripts to hide tools and simplify build and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,44 +33,23 @@ To build the code, follow these steps.
   ```shell
   npm install
   ```
-3. Ensure that [Gulp](http://gulpjs.com/) is installed. If you need to install it, use the following command:
+3. To build the code, you can now run:
 
   ```shell
-  npm install -g gulp
+  npm run build
   ```
-4. To build the code, you can now run:
+4. You will find the compiled code in the `dist` folder, available in three module formats: AMD, CommonJS and ES6.
 
-  ```shell
-  gulp build
-  ```
-5. You will find the compiled code in the `dist` folder, available in three module formats: AMD, CommonJS and ES6.
-
-6. See `gulpfile.js` for other tasks related to generating the docs and linting.
+5. See `gulpfile.js` for other tasks related to generating the docs and linting.
 
 ## Running The Tests
 
-To run the unit tests, first ensure that you have followed the steps above in order to install all dependencies and successfully build the library. Once you have done that, proceed with these additional steps:
+To run the unit tests, first ensure that you have followed the steps above in order to install all dependencies and successfully build the library. Once you have done that, proceed with this additional step:
 
-1. Ensure that the [Karma](http://karma-runner.github.io/) CLI is installed. If you need to install it, use the following command:
-
-  ```shell
-  npm install -g karma-cli
-  ```
-2. Ensure that [jspm](http://jspm.io/) is installed. If you need to install it, use the following commnand:
+1. You can now run the tests with this command:
 
   ```shell
-  npm install -g jspm
-  ```
-3. Install the client-side dependencies with jspm:
-
-  ```shell
-  jspm install
-  ```
-
-4. You can now run the tests with this command:
-
-  ```shell
-  karma start
+  npm test
   ```
   
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "type": "git",
     "url": "http://github.com/aurelia/framework"
   },
+  "scripts": {
+    "build": "gulp build",
+    "install": "jspm install",
+    "test": "karma start"
+  },
   "jspm": {
     "main": "system/index",
     "format": "register",
@@ -45,9 +50,11 @@
     "gulp-yuidoc": "^0.1.2",
     "jasmine-core": "^2.1.3",
     "jshint-stylish": "^1.0.0",
+    "jspm": "^0.10.6",
     "karma": "^0.12.28",
     "karma-6to5-preprocessor": "^1.0.0",
     "karma-chrome-launcher": "^0.1.7",
+    "karma-cli": "0.0.4",
     "karma-jasmine": "^0.3.2",
     "karma-jspm": "^1.0.1",
     "object.assign": "^1.0.3",


### PR DESCRIPTION
Using npm scripts it is possible to hide away the specific tools you're using. This way you have a tremendously simplified process for your users and a consistent API, should you ever decide to change tools.
CLA signed.