### PR TITLE
feat(build): add command line argument for semver bump. resolve #28

### DIFF
--- a/build/args.js
+++ b/build/args.js
@@ -1,0 +1,15 @@
+var yargs = require('yargs');
+
+var argv = yargs.argv;
+
+var validBumptypes = "major|minor|patch|prerelease".split("|");
+
+var bumpType = (argv.bumptype || 'patch').toLowerCase();
+
+if( validBumptypes.indexOf(bumpType) < 0) {
+  throw "Unrecognized bumptype '" + bumpType + "'.";
+}
+
+module.exports = {
+  versionBumpType: bumpType
+};

--- a/build/tasks/prepare-release.js
+++ b/build/tasks/prepare-release.js
@@ -1,13 +1,14 @@
 var gulp = require('gulp');
 var runSequence = require('run-sequence');
 var paths = require('../paths');
+var args = require('../args');
 var changelog = require('conventional-changelog');
 var fs = require('fs');
 var bump = require('gulp-bump');
 
 gulp.task('bump-version', function(){
   return gulp.src(['./package.json', './bower.json'])
-    .pipe(bump({type:'patch'})) //major|minor|patch|prerelease
+    .pipe(bump({type:args.versionBumpType })) //major|minor|patch|prerelease
     .pipe(gulp.dest('./'));
 });
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
-    "vinyl-paths": "^1.0.0"
+    "vinyl-paths": "^1.0.0",
+    "yargs": "^2.1.1"
   },
   "aurelia": {
     "usedBy": [


### PR DESCRIPTION
This feature will ease preparation for releases. Syntax is:

```Shell
gulp bump-version --bumptype=patch
```
If no argument value is supplied, patch will be use.

Valid values are: `major|minor|patch|prerelease`.
Supplying an invalid value will cause an error.