### PR TITLE
chore: add task 'cover' to run tests with code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ jspm_packages
 bower_components
 .idea
 .DS_STORE
+build/reports

--- a/build/tasks/test.js
+++ b/build/tasks/test.js
@@ -23,3 +23,24 @@ gulp.task('tdd', function (done) {
         done();
     });
 });
+
+/**
+ * Run test once with code coverage and exit
+ */
+gulp.task('cover', function (done) {
+  karma.start({
+    configFile: __dirname + '/../../karma.conf.js',
+    singleRun: true,
+    reporters: ['coverage'],
+    preprocessors: {
+      'test/**/*.js': ['babel'],
+      'src/**/*.js': ['babel', 'coverage']
+    },
+    coverageReporter: {
+      type: 'html',
+      dir: 'build/reports/coverage'
+    }
+  }, function (e) {
+    done();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.28",
     "karma-babel-preprocessor": "^5.1.0",
+    "karma-coverage": "^0.3.1",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
     "karma-jspm": "^1.1.4",


### PR DESCRIPTION
Signed CLA as Andreas Krummsdorf

You also might be interested in https://github.com/litixsoft/karma-detect-browsers, which allows you to run the karma tests in all browser of the current system. But thats another topic :-)

Additionally, i wonder you are using some kind of CI System? I found https://travis-ci.org very useful for open source projects. It's really easy to integrate and it will run the tests on every commit/pull-request.