### PR TITLE
fix(framework): Use correct import for core-js

### DIFF
--- a/src/aurelia.js
+++ b/src/aurelia.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import * as TheLogManager from 'aurelia-logging';
 import {Container} from 'aurelia-dependency-injection';
 import {Loader} from 'aurelia-loader';

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import * as TheLogManager from 'aurelia-logging';
 import {Metadata} from 'aurelia-metadata';
 


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177