### PR TITLE
(doc): minor grammar and spelling fixes

### DIFF
--- a/doc/article/en-US/a-production-setup.html
+++ b/doc/article/en-US/a-production-setup.html
@@ -44,7 +44,7 @@
       >
       > This also runs the `npm` and `jspm` commands listed below.
 
-      Inside the folder you will now find everything you need, including a basic build, package configuration, styles and more. With all this in place, let's run some commands.
+      You will now find everything you need inside the folder, including a basic build, package configuration, styles and more. With all this in place, let's run some commands.
 
       1. Open a console and change directory into your app's directory.
       2. Execute the following command to install the Gulp plugins listed in the _devDependencies_ section of the package manifest:

--- a/doc/article/en-US/business-advantages.html
+++ b/doc/article/en-US/business-advantages.html
@@ -8,21 +8,21 @@
 
   <body>
     <narrative uid="1" version="1.0">
-      ## Commerically Backed
+      ## Commercially Backed
 
       * One of the only two main-stream, open-source SPA frameworks with official commercial backing (Ember is the other).
       * The only SPA framework with commercial support options available.
       * Custom contracts available for enterprises.
       * Internally “dogfooded” by Durandal Inc. in its own business-critical products.
 
-      Many technologists make incorrect assumptions in this space. You may hear about "Google's Polymer" (or Angular) or "Facebook's React". However, these libraries aren't official products of their repsective companies. React team members have stated publicly that Facebook is not committed to the React library. Google developers have stated publicly that Polymer is not a Google product and developers are not considered customers. Angular and Polymer are two out of six UI libraries built by Google employees, all competative with one another, and none officially recognized by the company. There is much marketing and brand recognition around these libraries but no guarantee and little hope of long-term stability. We encourage you to try to see past the marketing, brands and hype and into the core capabilities and benefits of the technology itself. If you do, we think you'll realize that Aurelia is the best option available.
+      Many technologists make incorrect assumptions in this space. You may hear about "Google's Polymer" (or Angular) or "Facebook's React". However, these libraries aren't official products of their repsective companies. React team members have stated publicly that Facebook is not committed to the React library. Google developers have stated publicly that Polymer is not a Google product and developers are not considered customers. Angular and Polymer are two out of six UI libraries built by Google employees, all competitive with one another, and none officially recognized by the company. There is much marketing and brand recognition around these libraries but no guarantee and little hope of long-term stability. We encourage you to try to see past the marketing, brands and hype and into the core capabilities and benefits of the technology itself. If you do, we think you'll realize that Aurelia is the best option available.
     </narrative>
 
     <narrative uid="2" version="1.0">
       ## Commercial Products and Services
 
       * Official on-site or virtual training.
-      * Consulting, advisory and code-review services.
+      * Consulting, advisory, and code-review services.
       * Aurelia Interface (In Development) - Cross-platform, mobile UI components.
       * Aurelia Data Controls (In Development) - Data-oriented and LOB components.
       * Much more coming...
@@ -37,9 +37,9 @@
 
     <narrative uid="4" version="1.0">
       ## Broad Customer Reach
-      
+
       * Applications developed in virtually every space: healthcare, insurance, finance, entertainment, technology, developer tools, LOB, gaming, etc.
-      * Used internally at serveral, well-known enterprises.
+      * Used internally at several well-known enterprises.
       * Adoption among large, international organizations.
     </narrative>
   </body>

--- a/doc/article/en-US/technical-benefits.html
+++ b/doc/article/en-US/technical-benefits.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Technical Benefits</title>
-    <meta name="description" content="There are many technical advantages to using Aurelia. In this article you will find a list of points we think are interesting. Taken together, there is no other SPA framework today that can match Aurelia.">
+    <meta name="description" content="There are many technical advantages to using Aurelia. In this article, you will find a list of points we think are interesting. Taken together, there is no other SPA framework today that can match Aurelia.">
     <meta name="keywords" content="Benefits, Capabilities">
     <meta name="author" content="Rob Eisenberg">
   </head>


### PR DESCRIPTION
Git seems to think I made extensive changes to the first paragraph in `business-advantages.html`. All I did was fix the spelling of "competitive." Elsewhere, I fixed a few typos, added an Oxford comma, and removed an unnecessary comma.

I changed the sentence in `a-production-setup.html` to not use the passive voice.

I added a comma in `technical-benefits.html`.