### PR TITLE
Invalid JSON in Full Config example.

### DIFF
--- a/doc/article/en-US/bundling-your-app-for-deploy.md
+++ b/doc/article/en-US/bundling-your-app-for-deploy.md
@@ -345,7 +345,7 @@ We will also change the first bundle a little bit to exclude all the `html` and 
           options: {
             inject: {
               indexFile : 'index.html',
-              destFile : 'dest_index.html',
+              destFile : 'dest_index.html'
             }
           }
         }


### PR DESCRIPTION
 The bundles.json example in Full HTML Import Bundle Config has an extra comma that breaks `gulp bundle`.