### PR TITLE
(doc): add a clear example of dash-case to camelCase binding

### DIFF
--- a/doc/article/en-US/cheat-sheet.md
+++ b/doc/article/en-US/cheat-sheet.md
@@ -1506,6 +1506,7 @@ Since the VM's life-cycle is called only once you may have problems recognizing 
   </source-code>
 </code-listing>
 
+
 ### Custom Element Without View-Model Declaration
 
 Aurelia will not search for a JavaScript file if you reference a component with an .html extension.
@@ -1527,8 +1528,65 @@ Aurelia will not search for a JavaScript file if you reference a component with 
 <code-listing heading="Use Custom Element Without View-Model">
   <source-code lang="HTML">
     <require from="./js-less-component.html"></require>
-    
+
     <js-less-component name.bind="someProperty"></js-less-component>
+  </source-code>
+</code-listing>
+
+### Custom Element Variable Binding
+
+It's worth noting that when binding variables to custom elements, use camelCase inside the custom element's View-Model, and dash-case on the html element. See the following example:
+
+<code-listing heading="Custom Element View-Model Declaration">
+  <source-code lang="ES 2016">
+    import {customElement, bindable} from 'aurelia-framework';
+
+    @customElement('say-hello')
+    export class SayHello {
+      @bindable to;
+      @bindable greetingCallback
+
+      speak(){
+        this.greetingCallback(`Hello ${this.to}!`);
+      }
+    }
+  </source-code>
+  <source-code lang="ES 2015">
+    import {customElement, bindable} from 'aurelia-framework';
+
+    export let SayHello = decorators(
+      customElement('say-hello'),
+      bindable('to'),
+      bindable('greetingCallback')
+    ).on(class {
+      speak(){
+        this.greetingCallback(`Hello ${this.to}!`);
+      }
+    });
+  </source-code>
+  <source-code lang="TypeScript">
+    import {customElement, bindable} from 'aurelia-framework';
+
+    @customElement('say-hello')
+    export class SayHello {
+      @bindable to: string;
+      @bindable greetingCallback: function;
+
+      speak(): void {
+        this.greetingCallback(`Hello ${this.to}!`);
+      }
+    }
+  </source-code>
+</code-listing>
+
+<code-listing heading="Custom Element Use">
+  <source-code lang="HTML">
+    <template>
+      <require from="say-hello"></require>
+
+      <input type="text" ref="name">
+      <say-hello to.bind="name.value" greeting-callback.call="alert($event)"></say-hello>
+    </template>
   </source-code>
 </code-listing>
 


### PR DESCRIPTION
This tripped me up a couple of times when binding variables to custom elements, not sure if this is the best place exactly to put it, but I think it needs to be included somewhere.