### PR TITLE
fix: add type information for LogManager const

### DIFF
--- a/dist/aurelia-framework.d.ts
+++ b/dist/aurelia-framework.d.ts
@@ -212,5 +212,11 @@ declare module 'aurelia-framework' {
   /**
    * The log manager.
    */
-  export const LogManager: any;
+  export const LogManager: {
+	  logLevel: TheLogManager.LogLevel;
+	  getLogger(id: string): TheLogManager.Logger;
+	  addAppender(appender: TheLogManager.Appender): void;
+	  setLevel(level: number): void;
+	  Logger: TheLogManager.Logger;
+  };
 }


### PR DESCRIPTION
I'm not sure if this should be edited here, or if this file is generated. But it would be very helpful to have this type information so that auto-completion and error detection work on `LogManager.getLogger()`.