### PR TITLE
feat: add reference to TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "author": "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)",
   "main": "dist/commonjs/aurelia-framework.js",
+  "typings": "./dist/aurelia-framework.d.ts",
   "repository": {
     "type": "git",
     "url": "http://github.com/aurelia/framework"


### PR DESCRIPTION
[Typings for NPM packages](https://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html)
====================

> Try to load the `package.json` file located in the appropriate package folder (node_modules/foo/). If present,read the path to the typings file described in the "typings" field. For example, in the following `package.json`, the compiler will resolve the typings at `node_modules/foo/lib/foo.d.ts`

```javascript
{
    "name": "foo",
    "author": "Vandelay Industries",
    "version": "1.0.0",
    "main": "./lib/foo.js",
    "typings": "./lib/foo.d.ts"
}
```