### PR TITLE
doc(quick-start.md): consistency & method name err

### DIFF
--- a/doc/article/en-US/quick-start.md
+++ b/doc/article/en-US/quick-start.md
@@ -151,7 +151,7 @@ Our todo application contains a list of `Todo` instances. It can add and remove 
 
     export class App {
       constructor() {
-        this.heading = "Todos";
+        this.heading = 'Todos';
         this.todos = [];
         this.todoDescription = '';
       }
@@ -175,7 +175,7 @@ Our todo application contains a list of `Todo` instances. It can add and remove 
     import {Todo} from './todo';
 
     export class App {
-      heading = "Todos";
+      heading = 'Todos';
       todos: Todo[] = [];
       todoDescription = '';
 
@@ -343,7 +343,7 @@ Well, we can now add todos, but we can't see them! Let's remedy that by looking 
   </source-code>
 </code-listing>
 
-To generate HTML based on an Array, Map or Set, we use the `repeat.for="local of collection"` syntax. This syntax is derived from the `for...of` loop of ${context.language.name} itself. As you can see above, we want to generate one `li` for each item in our `todos` array. So, we place a `repeat.for` attribute on the `li` we want to be generated and we specify the `todos` collection and that we want the local loop variable to be named `todo`. With this we can bind to any property of the `todo` instance. So, you can see how we're just re-applying all the same techniques from above now. We're binding the `checked` attribute to the todo's `done` property and it's `description` property is being injected into the content of the `span`. Finally, we're adding a `trigger` on the button's `click` event so that we can remove the todo. Notice that the `removeTodo` is still in scope. Just like in ${context.language.name}, inside a loop, you still have access to the variable in the outer block. This allows us to call the `addTodo` method on the App class, passing in the particular `Todo` instance that we want to remove.
+To generate HTML based on an Array, Map or Set, we use the `repeat.for="local of collection"` syntax. This syntax is derived from the `for...of` loop of ${context.language.name} itself. As you can see above, we want to generate one `li` for each item in our `todos` array. So, we place a `repeat.for` attribute on the `li` we want to be generated and we specify the `todos` collection and that we want the local loop variable to be named `todo`. With this we can bind to any property of the `todo` instance. So, you can see how we're just re-applying all the same techniques from above now. We're binding the `checked` attribute to the todo's `done` property and it's `description` property is being injected into the content of the `span`. Finally, we're adding a `trigger` on the button's `click` event so that we can remove the todo. Notice that the `removeTodo` is still in scope. Just like in ${context.language.name}, inside a loop, you still have access to the variable in the outer block. This allows us to call the `removeTodo` method on the App class, passing in the particular `Todo` instance that we want to remove.
 
 If you run the application again, you should now see something like this:
 


### PR DESCRIPTION
- Changed double quotes to single quotes in a pair of strings, because there was mixing of double quotes/single quotes for strings in TypeScript/JavaScript, so consistency.
- Changed `addTodo` for `removeTodo` where the doc is talking about the method associated to the remove `button`, because, well, it's what that button does (last line of the paragraph).

Also spotted `string` spelled `sting`, but didn't change that, because, well, there is already a PR #502.