### PR TITLE
Correct bundle paragraph

### DIFF
--- a/doc/article/en-US/contact-manager-tutorial.md
+++ b/doc/article/en-US/contact-manager-tutorial.md
@@ -158,7 +158,7 @@ Next, because Bootstrap uses jQuery, we want to install jQuery as well, like thi
 npm install jquery@^2.2.4 --save
 ```
 
-With these libraries installed, we now need to tell Aurelia which application bundle they should be included in and how to properly configure then with the module system. To do this, look in the `aurelia_project` folder and open up the `aurelia.json` file. This file contains all the information that the Aurelia CLI uses to build our project. If you scroll down, you will see a `bundles` section. There are two bundles defined by default: `app-bundle.js`, which contains your code and `vendor-bundle.js` which contains all 3rd party libraries. We need to add a new items to the `dependencies` array of the `app-bundle.js` bundle. Add the following two entries for jQuery and Bootstrap:
+With these libraries installed, we now need to tell Aurelia which application bundle they should be included in and how to properly configure then with the module system. To do this, look in the `aurelia_project` folder and open up the `aurelia.json` file. This file contains all the information that the Aurelia CLI uses to build our project. If you scroll down, you will see a `bundles` section. There are two bundles defined by default: `app-bundle.js`, which contains your code and `vendor-bundle.js` which contains all 3rd party libraries. We need to add some new items to the `dependencies` array of the `vector-bundle.js` bundle. Add the following two entries for jQuery and Bootstrap:
 
 <code-listing heading="jQuery and Bootstrap Bundle Config">
   <source-code lang="JavaScript">


### PR DESCRIPTION
The paragraph describing the bundles talks about adding "a new items" to the "app-bundle.js".
This should  something like "some new items" and it should be to the vector-bundle.js as they are third party (also app-bundle does not have an existing dependencies array to add to).

There is another pull request for this it appears - I only noticed it after making the change, but it doesn't correct the 'a new items' part.