### PR TITLE
doc(contact-manager): version consistency change

### DIFF
--- a/doc/article/en-US/contact-manager-tutorial.md
+++ b/doc/article/en-US/contact-manager-tutorial.md
@@ -73,7 +73,20 @@ In the picture, you can see that we have a header across the top, a contact list
 To begin, we're going to setup our `App` class by configuring it with a router. We want our browser history to reflect which contact in our list is selected, so we'll introduce a client-side router to handle the navigation from screen to screen. Replace the code in your `app${context.language.fileExtension}` with the following:
 
 <code-listing heading="app${context.language.fileExtension}">
-  <source-code lang="ES 2015/ES Next">
+  <source-code lang="ES 2015">
+    export class App {
+      configureRouter(config, router){
+        config.title = 'Contacts';
+        config.map([
+          { route: '',              moduleId: 'no-selection',   title: 'Select'},
+          { route: 'contacts/:id',  moduleId: 'contact-detail', name:'contacts' }
+        ]);
+
+        this.router = router;
+      }
+    }
+  </source-code>
+  <source-code lang="ES Next">
     export class App {
       configureRouter(config, router){
         config.title = 'Contacts';
@@ -235,7 +248,7 @@ Aurelia strives to be a self-consistent framework. As such, building a custom el
     import {WebAPI} from './web-api';
 
     export class ContactList {
-      static inject() { return [WebAPI] };
+      static inject() { return [WebAPI]; }
 
       constructor(api){
         this.api = api;
@@ -629,7 +642,7 @@ Whenever the contact detail screen successfully saves a contact, we'll publish t
     import {areEqual} from './utility';
 
     export class ContactDetail {
-      static inject = [WebAPI, EventAggregator];
+      static inject() { return [WebAPI, EventAggregator]; }
 
       constructor(api, ea){
         this.api = api;
@@ -801,7 +814,7 @@ With this messages in place, we can now enable any other component in our system
     import {ContactUpdated, ContactViewed} from './messages';
 
     export class ContactList {
-      static inject = [WebAPI, EventAggregator];
+      static inject() { return [WebAPI, EventAggregator]; }
 
       constructor(api, ea){
         this.api = api;


### PR DESCRIPTION
While working through the tutorial I noticed that the original app.js file displayed was inconsistent with the final file state at the end of the tutorial. Upon inspection of the source I speculated that naming the lang variable 'ES 2015/ES NEXT' may have tampered with the view rendering method. (New to this so have not investigated the internal interaction). This commit creates a duplicate template with the separate name. 

I also noticed throughout that ES NEXT is often not rendered when selected in the tutorial. I wasn't sure if this was just for future release purposes or if there is something wrong with the selection. Would be happy to submit a more detailed issue for that. 

Finally, I noticed some inconsistency with the way the dependency injection was written for the ES 2015 specification. I changed one error with semi-colon placement, and also changed the format to reflect the style in which the dependency injection tutorial describes it. I've taken a look through the issues and pull requests and didn't notice anything like this but if I missed something let me know (This is my first pull request)!

No breaking changes.
