### PR TITLE
Add more type information to Typescript AuthorizeStep

### DIFF
--- a/doc/article/en-US/securing-your-app.md
+++ b/doc/article/en-US/securing-your-app.md
@@ -66,12 +66,12 @@ You can improve the user-experience by plugging into Aurelia's router pipeline w
     }
   </source-code>
   <source-code lang="TypeScript">
-    import {Redirect, NavigationInstruction, RouterConfiguration} from 'aurelia-router';
+    import {NavigationInstruction, Next, PipelineStep, Redirect, RouterConfiguration} from 'aurelia-router';
 
     export class App {
       configureRouter(config: RouterConfiguration): void {
         config.title = 'Aurelia';
-        config.addPipelineStep('authorize', AuthorizeStep);
+        config.addAuthorizeStep(AuthorizeStep);
         config.map([
           { route: ['welcome'], moduleId: 'welcome', title: 'Welcome', settings: { roles: [] } },
           { route: 'admin', moduleId: 'admin', title: 'Admin' settings: { roles: ['admin'] } }
@@ -79,8 +79,8 @@ You can improve the user-experience by plugging into Aurelia's router pipeline w
       }
     }
 
-    class AuthorizeStep {
-      run(navigationInstruction: NavigationInstruction, next: Function): Promise<any> {
+    class AuthorizeStep implements PipelineStep {
+      public run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
         if (navigationInstruction.getAllInstructions().some(i => i.config.settings.roles.indexOf('admin') !== -1)) {
           var isAdmin = /* insert magic here */false;
           if (!isAdmin) {


### PR DESCRIPTION
doc: Add more type information to Typescript AuthorizeStep

Having the run function's second parameter, in the AuthorizeStep class, as Function was giving me errors in Typescript as a 'Function' type has no 'cancel' property. In addition to updating that, I added some additional type information to the rest of the class.