### PR TITLE
doc(contact-manager): Do not use "ES Next" source-code lang attribute

### DIFF
--- a/doc/article/en-US/contact-manager-tutorial.md
+++ b/doc/article/en-US/contact-manager-tutorial.md
@@ -251,7 +251,7 @@ Aurelia strives to be a self-consistent framework. As such, building a custom el
       }
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     import {WebAPI} from './web-api';
     import {inject} from 'aurelia-framework';
 
@@ -411,7 +411,7 @@ Again, this is because the router is trying to route to the detail screen, but w
       }
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     import {inject} from 'aurelia-framework';
     import {WebAPI} from './web-api';
     import {areEqual} from './utility';
@@ -596,7 +596,7 @@ The reason for these issues is that we have two separate components, our `contac
       }
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     export class ContactUpdated {
       constructor(contact){
         this.contact = contact;
@@ -676,7 +676,7 @@ Whenever the contact detail screen successfully saves a contact, we'll publish t
       }
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     import {inject} from 'aurelia-framework';
     import {EventAggregator} from 'aurelia-event-aggregator';
     import {WebAPI} from './web-api';
@@ -826,7 +826,7 @@ With these messages in place, we can now enable any other component in our syste
       }
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     import {EventAggregator} from 'aurelia-event-aggregator';
     import {WebAPI} from './web-api';
     import {ContactUpdated, ContactViewed} from './messages';
@@ -947,7 +947,7 @@ With that in place, let's create our `loading-indicator` custom element. In the 
       }
     });
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     import * as nprogress from 'nprogress';
     import {bindable, noView} from 'aurelia-framework';
 
@@ -995,7 +995,7 @@ Previously, when we created the `contact-list` component, we required that into 
       config.globalResources(['./elements/loading-indicator']);
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     export function configure(config) {
       config.globalResources(['./elements/loading-indicator']);
     }
@@ -1033,7 +1033,7 @@ With this registration in place, we can now use our new indicator in our `app.ht
       }
     }
   </source-code>
-  <source-code lang="ES Next">
+  <source-code lang="ES 2016">
     import {inject} from 'aurelia-framework';
     import {WebAPI} from './web-api';
 


### PR DESCRIPTION
Resolves [issue](https://github.com/aurelia/documentation/issues/297)

Current language gets set as ES 2016 (because that happens when the user clicks on ES Next in the dropdown) and there was no ES 2016 in availableSources (because there was ES Next), so the code for ES 2015 was being shown.