### PR TITLE
style(comments): added comments about moduleName

### DIFF
--- a/src/framework-configuration.js
+++ b/src/framework-configuration.js
@@ -285,6 +285,14 @@ export class FrameworkConfiguration {
     return this;
   }
 
+  // Default configuration helpers
+  // Note: Please do NOT add PLATFORM.moduleName() around those module names.
+  //       Those functions are not guaranteed to be called, they are here to faciliate 
+  //       common configurations. If they are not called, we don't want to include a 
+  //       static dependency on those modules.
+  //       Including those modules in the bundle or not is a decision that must be
+  //       taken by the bundling tool, at build time.
+
   /**
    * Plugs in the default binding language from aurelia-templating-binding.
    * @return Returns the current FrameworkConfiguration instance.


### PR DESCRIPTION
Left a comment explaining why we don't want to use PLATFORM.moduleName here, although there are plenty of module names in the file.

See aurelia/pal#21