### PR TITLE
fix(startup): start() incorrectly returns a resolved promise

### DIFF
--- a/src/aurelia.js
+++ b/src/aurelia.js
@@ -69,14 +69,12 @@ export class Aurelia {
    * @return Returns a Promise with the started Aurelia instance.
    */
   start(): Promise<Aurelia> {
-    if (this.started) {
-      return Promise.resolve(this);
+    if (this._started) {
+      return this._started;
     }
 
-    this.started = true;
     this.logger.info('Aurelia Starting');
-
-    return this.use.apply().then(() => {
+    return this._started = this.use.apply().then(() => {
       preventActionlessFormSubmit();
 
       if (!this.container.hasResolver(BindingLanguage)) {


### PR DESCRIPTION
`start()` had some kind of race condition, as it would return a resolved Promise before the startup process actually completed. An illustration of the problem:
```js
let p1 = aurelia.start();  
// p1 is pending
let p2 = aurelia.start(); 
// p2 is resolved
```
In addition to being settled too early, that second Promise could resolve although the startup process ultimately rejects.

The code above looks dumb, but a realist application could be a plugin that wants to execute something after its application has started. An easy way to do that is:
```js
// In plugin/index.js
export function configure(aurelia) {
  aurelia.start().then(() => /* do stuff when started */);
}
```

CC @niieani 