### PR TITLE
feat(config): .feature() accepts explicit /index.

### DIFF
--- a/src/framework-configuration.js
+++ b/src/framework-configuration.js
@@ -202,12 +202,15 @@ export class FrameworkConfiguration {
    * @param config The configuration for the specified plugin.
    * @return Returns the current FrameworkConfiguration instance.
    */
-  feature(plugin: string, config?: any): FrameworkConfiguration {
-    if (getExt(plugin)) {
-      return this.plugin({ moduleId: plugin, resourcesRelativeTo: [plugin, ''], config: config || {} });
-    }
-
-    return this.plugin({ moduleId: plugin + '/index', resourcesRelativeTo: [plugin, ''], config: config || {} });
+  feature(plugin: string, config?: any = {}): FrameworkConfiguration {
+    let hasIndex = /\/index$/i.test(plugin);
+    let moduleId = hasIndex || getExt(plugin) ? 
+                      plugin : 
+                      plugin + '/index';
+    let root = hasIndex ? 
+                  plugin.substr(0, plugin.length - 6) : 
+                  plugin;
+    return this.plugin({ moduleId, resourcesRelativeTo: [root, ''], config });
   }
 
   /**


### PR DESCRIPTION
I modified `feature()` so that it accepts explicits `/index` inputs. 
This change makes the API play nice with our new `moduleName`, like so:
```js
aurelia.use.feature(PLATFORM.moduleName('data-grid/index'))
```

I discovered that the original code had support for extensions, like you could pass `data-grid/index.js`. 
I left that behavior unchanged, although it seems to me that `resourcesRelativeTo` is inconsistent when using that code path 😶 
