### PR TITLE
Correct typo in copyFiles JSON

### DIFF
--- a/doc/article/en-US/the-aurelia-cli.md
+++ b/doc/article/en-US/the-aurelia-cli.md
@@ -266,7 +266,7 @@ The final step to make Bootstrap work is to copy the necessary font files to the
 ```
 "bundles": [ ... ], 
 "copyFiles": {
-    "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff2": "bootstrap/fonts".
+    "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff2": "bootstrap/fonts",
     "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff": "bootstrap/fonts",
     "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf": "bootstrap/fonts"
   }


### PR DESCRIPTION
I followed the tutorial and this stumped me because of invalid JSON.