### PR TITLE
doc(the-aurelia-cli.md): Add external dependency upgrade script

### DIFF
--- a/doc/article/en-US/the-aurelia-cli.md
+++ b/doc/article/en-US/the-aurelia-cli.md
@@ -518,7 +518,7 @@ exec(`yarn upgrade ${depsToUpdate}`);
 
 ```
 "scripts": {
-  "au-update": "au-update": "node ./aurelia_project/tasks/au-update.js"
+  "au-update": "node ./aurelia_project/tasks/au-update.js"
 }
 
 * This will find the easily updatable dependencies in each bundles dependencies list and update them.

--- a/doc/article/en-US/the-aurelia-cli.md
+++ b/doc/article/en-US/the-aurelia-cli.md
@@ -508,6 +508,7 @@ let depsToUpdate =
     _.chain(bundles)
      .flatMap(bundle => bundle.dependencies)
      .filter(dep => _.isString(dep))
+     .filter(dep => _.contains(dep, "aurelia"))
      .reduce((deps, dep) => `${deps} ${dep}`)
      .value();
 

--- a/doc/article/en-US/the-aurelia-cli.md
+++ b/doc/article/en-US/the-aurelia-cli.md
@@ -492,3 +492,34 @@ To update a single library use the command `npm install library-name` where libr
 * List the libraries on a single line separated by a space.
 * Include all of the libraries from the dependencies section of aurelia.json that you want to update.
 * Use the command `npm run au-update` to update all of the libraries in the au-update list above.
+
+## [Updating Multiple Libraries using an external script](aurelia-doc://section/17/version/1.0.0)
+
+* Add the following section to an `au-update.js` file in your aurelia_project/tasks folder.
+
+```
+let project = require('../aurelia.json')
+let exec = require('child_process').exec
+let _ = require('lodash')
+
+var bundles = project.build.bundles
+
+let depsToUpdate =
+    _.chain(bundles)
+     .flatMap(bundle => bundle.dependencies)
+     .filter(dep => _.isString(dep))
+     .reduce((deps, dep) => `${deps} ${dep}`)
+     .value();
+
+exec(`yarn upgrade ${depsToUpdate}`);
+```
+
+* Add the following section to the projects `package.json` file:
+
+```
+"scripts": {
+  "au-update": "au-update": "node ./aurelia_project/tasks/au-update.js"
+}
+
+* This will find the easily updatable dependencies in each bundles dependencies list and update them.
+* 'easily updatable' means that the dependency doesn't have any additional properties, and is listed as a string in aurelia.json


### PR DESCRIPTION
This addition to the documentation describes an alternative method of updating dependencies by specifying an external script that inspects the aurelia.json project, finds updatable dependencies and updates them. It's a useful alternative to listing all of the dependencies in an npm-script as the previous step describes.

It's possible that the list might need to be filtered to deps containing 'aurelia', but that could be left up to the implementer.

Unfortunately the script is quiet at the moment...I haven't piped through the events from the child process, something we could do if there was interest :).

Is this method of updating too error-prone?