### PR TITLE
fix(786) documentation says export instead of exports

### DIFF
--- a/doc/article/en-US/the-aurelia-cli.md
+++ b/doc/article/en-US/the-aurelia-cli.md
@@ -221,7 +221,7 @@ Libraries that predate module systems can be a pain because they often rely on g
         "name":"jquery",
         "path":"../node_modules/jquery/dist",
         "main":"jquery.min",
-        "export": "$"
+        "exports": "$"
       },
       {
           "name": "bootstrap",
@@ -253,7 +253,7 @@ The Bootstrap example above results in the bundling of the JavaScript portions o
         "name":"jquery",
         "path":"../node_modules/jquery/dist",
         "main":"jquery.min",
-        "export": "$"
+        "exports": "$"
       },
       {
           "name": "bootstrap",


### PR DESCRIPTION
I'm submitting a bug fix

Current behavior:

http://aurelia.io/hub.html#/doc/article/aurelia/framework/latest/bundling-jspm/9

{
    "name":"jquery",
    "path":"../node_modules/jquery/dist",
    "main":"jquery.min",
    "export": "$"
  }
is incorrect

Expected/desired behavior:

{
    "name":"jquery",
    "path":"../node_modules/jquery/dist",
    "main":"jquery.min",
    "exports": "$"
  }
as per http://requirejs.org/docs/api.html

What is the motivation / use case for changing the behavior?
avoid confusion for folks using old libraries