### PR TITLE
doc(aurelia-cli): export -> exports

### DIFF
--- a/doc/article/en-US/the-aurelia-cli.md
+++ b/doc/article/en-US/the-aurelia-cli.md
@@ -222,7 +222,7 @@ Libraries that predate module systems can be a pain because they often rely on g
         "name":"jquery",
         "path":"../node_modules/jquery/dist",
         "main":"jquery.min",
-        "export": "$"
+        "exports": "$"
       },
       {
           "name": "bootstrap",
@@ -254,7 +254,7 @@ The Bootstrap example above results in the bundling of the JavaScript portions o
         "name":"jquery",
         "path":"../node_modules/jquery/dist",
         "main":"jquery.min",
-        "export": "$"
+        "exports": "$"
       },
       {
           "name": "bootstrap",


### PR DESCRIPTION
The dependency config has a property called [`exports`](https://github.com/aurelia/cli/blob/master/lib/build/bundler.js#L142), not `export`