### PR TITLE
feat(config): ability to declare global resources by classes

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ System.config({
     "aurelia-pal": "npm:aurelia-pal@1.0.0",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0",
     "aurelia-path": "npm:aurelia-path@1.0.0",
+    "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0",
     "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0",
     "aurelia-templating": "npm:aurelia-templating@1.0.0",
     "babel": "npm:babel-core@5.8.38",
@@ -62,6 +63,9 @@ System.config({
       "aurelia-pal": "npm:aurelia-pal@1.0.0"
     },
     "npm:aurelia-pal-browser@1.0.0": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0"
+    },
+    "npm:aurelia-polyfills@1.0.0": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0"
     },
     "npm:aurelia-task-queue@1.0.0": {

--- a/dist/aurelia-framework.d.ts
+++ b/dist/aurelia-framework.d.ts
@@ -84,6 +84,13 @@ export declare class Aurelia {
   setRoot(root?: string, applicationHost?: string | Element): Promise<Aurelia>;
 }
 
+export declare interface GlobalResources {
+  customElements?: Function[]
+  customAttributes?: Function[]
+  bindingBehaviors?: Function[]
+  valueConverters?: Function[]
+}
+
 /**
  * Manages configuring the aurelia framework instance.
  */
@@ -152,11 +159,13 @@ export declare class FrameworkConfiguration {
   feature(plugin: string, config?: any): FrameworkConfiguration;
 
   /**
-     * Adds globally available view resources to be imported into the Aurelia framework.
-     * @param resources The relative module id to the resource. (Relative to the plugin's installer.)
-     * @return Returns the current FrameworkConfiguration instance.
-     */
-  globalResources(resources: string | string[]): FrameworkConfiguration;
+   * Adds globally available view resources to be imported into the Aurelia framework.
+   * @param resources The relative module id to the resource. (Relative to the plugin's installer.)
+   * @return Returns the current FrameworkConfiguration instance.
+   */
+  globalResources(globals: GlobalResources): FrameworkConfiguration;
+  globalResources(...resources: (string | Function)[]): FrameworkConfiguration;
+  globalResources(resources: string | string[] | Function | Function[]): FrameworkConfiguration;
 
   /**
      * Renames a global resource that was imported.
@@ -227,6 +236,30 @@ export declare class FrameworkConfiguration {
      * @return Returns a promise which resolves when all plugins are loaded and configured.
     */
   apply(): Promise<void>;
+
+  /**
+   * Explicitly register an implementation as custom element
+   * @param impl Custom element view model class
+   */
+  customElement(impl: Function): void;
+
+  /**
+   * Explicitly register an implementation as custom attribute
+   * @param impl Custom attribute view model class
+   */
+  customAttribute(impl: Function): void;
+
+  /**
+   * Explicitly register an implementation as binding behavior
+   * @param impl Binding behavior class
+   */
+  bindingBehavior(impl: Function): void;
+
+  /**
+   * Explicitly register an implementation as value converter
+   * @param impl Value converter class
+   */
+  valueConverter(impl: Function): void;
 }
 export * from 'aurelia-dependency-injection';
 export * from 'aurelia-binding';
@@ -239,4 +272,4 @@ export * from 'aurelia-pal';
 /**
    * The log manager.
    */
-  export const LogManager: any;
+export const LogManager: any;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     },
     "devDependencies": {
       "aurelia-pal-browser": "^1.0.0-rc.1.0.0",
+      "aurelia-polyfills": "^1.3.0",
       "babel": "babel-core@^5.8.24",
       "babel-runtime": "^5.8.24",
       "core-js": "^2.0.3"
@@ -68,6 +69,7 @@
     "aurelia-templating": "^1.0.0"
   },
   "devDependencies": {
+    "aurelia-polyfills": "^1.3.0",
     "aurelia-tools": "^0.2.4",
     "babel-dts-generator": "^0.6.1",
     "babel-eslint": "^6.1.2",
@@ -113,79 +115,5 @@
     "vinyl": "^1.1.1",
     "vinyl-paths": "^2.1.0",
     "yargs": "^4.8.1"
-  },
-  "aurelia": {
-    "documentation": {
-      "articles": [
-        {
-          "title": "What is Aurelia?",
-          "href": "doc/article/en-US/what-is-aurelia.md"
-        },
-        {
-          "title": "Quick Start",
-          "href": "doc/article/en-US/quick-start.md"
-        },
-        {
-          "title": "Contact Manager Tutorial",
-          "href": "doc/article/en-US/contact-manager-tutorial.md"
-        },
-        {
-          "title": "The Aurelia CLI",
-          "href": "doc/article/en-US/the-aurelia-cli.md"
-        },
-        {
-          "title": "JSPM Setup",
-          "href": "doc/article/en-US/setup-jspm.md"
-        },
-        {
-          "title": "JSPM Bundling",
-          "href": "doc/article/en-US/bundling-jspm.md"
-        },
-        {
-          "title": "Webpack Setup",
-          "href": "doc/article/en-US/setup-webpack.md"
-        },
-        {
-          "title": "Webpack Bundling",
-          "href": "doc/article/en-US/bundling-webpack.md"
-        },
-        {
-          "title": "Creating Components",
-          "href": "doc/article/en-US/creating-components.md"
-        },
-        {
-          "title": "App Configuration and Startup",
-          "href": "doc/article/en-US/app-configuration-and-startup.md"
-        },
-        {
-          "title": "Securing Your App",
-          "href": "doc/article/en-US/securing-your-app.md"
-        },
-        {
-          "title": "Cheat Sheet",
-          "href": "doc/article/en-US/cheat-sheet.md"
-        },
-        {
-          "title": "Getting Help",
-          "href": "doc/article/en-US/getting-help.md"
-        },
-        {
-          "title": "Technical Benefits",
-          "href": "doc/article/en-US/technical-benefits.md"
-        },
-        {
-          "title": "Business Advantages",
-          "href": "doc/article/en-US/business-advantages.md"
-        },
-        {
-          "title": "Integrating with Polymer",
-          "href": "doc/article/en-US/integrating-with-polymer.md"
-        },
-        {
-          "title": "Migrating from Angular 1",
-          "href": "doc/article/en-US/migrating-from-angular-1.md"
-        }
-      ]
-    }
   }
 }

--- a/src/framework-configuration.js
+++ b/src/framework-configuration.js
@@ -1,7 +1,25 @@
 import * as TheLogManager from 'aurelia-logging';
-import {ViewEngine} from 'aurelia-templating';
+import { camelCase, ValueConverterResource, BindingBehaviorResource } from 'aurelia-binding';
+import {ViewEngine, ViewResources, HtmlBehaviorResource, _hyphenate} from 'aurelia-templating';
 import {join} from 'aurelia-path';
 import {Container} from 'aurelia-dependency-injection';
+import { metadata } from 'aurelia-metadata';
+
+
+/**
+ * @typedef ConfigInfo
+ * @prop {string} moduleId
+ * @prop {string[]} resourcesRelativeTo
+ * @prop {any} config
+ */
+
+ /**
+  * @typedef GlobalResources
+  * @prop {Function[]} valueConverters
+  * @prop {Function[]} bindingBehaviors
+  * @prop {Function[]} customElements
+  * @prop {Function[]} customAttributes
+  */
 
 const logger = TheLogManager.getLogger('aurelia');
 const extPattern = /\.[^/.]+$/;
@@ -20,7 +38,7 @@ function runTasks(config, tasks) {
   return next();
 }
 
-function loadPlugin(config, loader, info) {
+function loadPlugin(config: FrameworkConfiguration, loader, info: ConfigInfo) {
   logger.debug(`Loading plugin ${info.moduleId}.`);
   config.resourcesRelativeTo = info.resourcesRelativeTo;
 
@@ -48,7 +66,7 @@ function loadPlugin(config, loader, info) {
   }
 }
 
-function loadResources(aurelia, resourcesToLoad, appResources) {
+function loadResources(aurelia, resourcesToLoad, appResources: ViewResources) {
   let viewEngine = aurelia.container.get(ViewEngine);
 
   return Promise.all(Object.keys(resourcesToLoad).map(n => _normalize(resourcesToLoad[n])))
@@ -98,6 +116,20 @@ function loadResources(aurelia, resourcesToLoad, appResources) {
   }
 }
 
+function loadBehaviors(container: Container, behaviors: HtmlBehaviorResource[]) {
+  let current;
+  let next = () => {
+    current = behaviors.shift();
+    if (current) {
+      return current.load(container, current.target).then(next);
+    }
+
+    return Promise.resolve();
+  };
+
+  return next();
+}
+
 function getExt(name) { // eslint-disable-line consistent-return
   let match = name.match(extPattern);
   if (match && match.length > 0) {
@@ -105,7 +137,7 @@ function getExt(name) { // eslint-disable-line consistent-return
   }
 }
 
-function assertProcessed(plugins) {
+function assertProcessed(plugins: FrameworkConfiguration) {
   if (plugins.processed) {
     throw new Error('This config instance has already been applied. To load more plugins or global resources, create a new FrameworkConfiguration instance.');
   }
@@ -132,13 +164,18 @@ export class FrameworkConfiguration {
   constructor(aurelia: Aurelia) {
     this.aurelia = aurelia;
     this.container = aurelia.container;
+    /**@type {ConfigInfo[]} */
     this.info = [];
+    /**@type {HtmlBehaviorResource[]} */
+    this.globalBehaviors = [];
     this.processed = false;
     this.preTasks = [];
     this.postTasks = [];
     this.resourcesToLoad = {};
     this.preTask(() => aurelia.loader.normalize('aurelia-bootstrapper').then(name => this.bootstrapperName = name));
-    this.postTask(() => loadResources(aurelia, this.resourcesToLoad, aurelia.resources));
+    this.postTask(() => loadResources(aurelia, this.resourcesToLoad, aurelia.resources)
+      .then(() => loadBehaviors(this.container, this.globalBehaviors))
+    );
   }
 
   /**
@@ -214,8 +251,18 @@ export class FrameworkConfiguration {
    * @param resources The relative module id to the resource. (Relative to the plugin's installer.)
    * @return Returns the current FrameworkConfiguration instance.
    */
-  globalResources(resources: string|string[]): FrameworkConfiguration {
+  globalResources(resources: GlobalResources | string | string[] | Function | Function[]): FrameworkConfiguration {
     assertProcessed(this);
+
+    if (arguments.length === 1) {
+      let firstArg = arguments[0];
+      // When there is only one argument, and it's an object, and not an array
+      // it's the shape on explicit global()
+      if (firstArg && typeof firstArg === 'object' && !Array.isArray(firstArg)) {
+        this.global(firstArg);
+        return this;
+      }
+    }
 
     let toAdd = Array.isArray(resources) ? resources : arguments;
     let resource;
@@ -223,21 +270,84 @@ export class FrameworkConfiguration {
 
     for (let i = 0, ii = toAdd.length; i < ii; ++i) {
       resource = toAdd[i];
-      if (typeof resource !== 'string') {
-        throw new Error(`Invalid resource path [${resource}]. Resources must be specified as relative module IDs.`);
+      if (!resource) {
+        throw new Error('Invalid resource declaration. Expected module name or a class');
       }
+      if (typeof resource === 'string') {
+        let parent = resourcesRelativeTo[0];
+        let grandParent = resourcesRelativeTo[1];
+        let name = resource;
 
-      let parent = resourcesRelativeTo[0];
-      let grandParent = resourcesRelativeTo[1];
-      let name = resource;
+        if ((resource.startsWith('./') || resource.startsWith('../')) && parent !== '') {
+          name = join(parent, resource);
+        }
 
-      if ((resource.startsWith('./') || resource.startsWith('../')) && parent !== '') {
-        name = join(parent, resource);
+        this.resourcesToLoad[name] = { moduleId: name, relativeTo: grandParent };
+      } else {
+        let resourceTypeMeta = metadata.get(metadata.resource, resource);
+
+        if (resourceTypeMeta) {
+          // Sometimes the resources might have been declared lazily, without a
+          // reliable name. Going through their corresponding resource resigration ensures it
+          if (resourceTypeMeta instanceof HtmlBehaviorResource) {
+            // When it's either custom element or custom attribute
+            if (resourceTypeMeta.attributeName !== null) {
+              this.customAttribute(resource);
+            } else {
+              this.customElement(resource);
+            }
+          } else if (resourceTypeMeta instanceof BindingBehaviorResource) {
+            this.bindingBehavior(resource);
+          } else if (resourceTypeMeta instanceof ValueConverterResource) {
+            this.valueConverter(resource);
+          } else {
+            logger.warn(`Invalid resource registered for ${resource.name}`);
+          }
+        } else {
+          // When there is no explicit resources defined
+          let className = resource.name;
+          if (resourceTypeMeta = HtmlBehaviorResource.convention(className)
+            || BindingBehaviorResource.convention(className)
+            || ValueConverterResource.convention(className)
+          ) {
+            resourceTypeMeta.initialize(this.container, resource);
+            resourceTypeMeta.register(this.aurelia.resources);
+
+            if (resourceTypeMeta.elementName) {
+              this.globalBehaviors.push(resourceTypeMeta);
+            }
+          } else {
+            // When there is no explicit configuration and there is no convention
+            // It's a custom element
+            this.customElement(resource);
+          }
+        }
       }
-
-      this.resourcesToLoad[name] = { moduleId: name, relativeTo: grandParent };
     }
+    return this;
+  }
 
+  global(resources) {
+    if (!resources || typeof resources !== 'object') {
+      logger.warn('No global resources declared.');
+      return;
+    }
+    const elements = resources.customElements;
+    if (elements) {
+      elements.forEach(this.customElement, this);
+    }
+    const attributes = resources.customAttributes;
+    if (attributes) {
+      attributes.forEach(this.customAttribute, this);
+    }
+    const bindingBehaviors = resources.bindingBehaviors;
+    if (bindingBehaviors) {
+      bindingBehaviors.forEach(this.bindingBehavior, this);
+    }
+    const valueConverters = resources.valueConverters;
+    if (valueConverters) {
+      valueConverters.forEach(this.valueConverter, this);
+    }
     return this;
   }
 
@@ -391,5 +501,56 @@ export class FrameworkConfiguration {
 
       return next().then(() => runTasks(this, this.postTasks));
     });
+  }
+
+  customElement(impl: Function) {
+    const aurelia = this.aurelia;
+    let resource = metadata.getOwn(metadata.resource, impl);
+    if (!resource) {
+      resource = new HtmlBehaviorResource();
+      resource.elementName = _hyphenate(impl.name);
+    } else if (!(resource instanceof HtmlBehaviorResource)) {
+      throw new Error(`Resource defined at ${impl.name} is not a custom element.`);
+    }
+    resource.initialize(aurelia.container, impl);
+    resource.register(aurelia.resources);
+    this.globalBehaviors.push(resource);
+  }
+
+  customAttribute(impl: Function) {
+    const aurelia = this.aurelia;
+    let resource = metadata.getOwn(metadata.resource, impl);
+    if (!resource) {
+      resource = new HtmlBehaviorResource();
+      resource.attributeName = _hyphenate(impl.name);
+    } else if (!(resource instanceof HtmlBehaviorResource)) {
+      throw new Error(`Resource defined at ${impl.name} is not a custom attribute.`);
+    }
+    resource.initialize(aurelia.container, impl);
+    resource.register(aurelia.resources);
+  }
+
+  bindingBehavior(impl: Function) {
+    const aurelia = this.aurelia;
+    let resource = metadata.getOwn(metadata.resource, impl);
+    if (!resource) {
+      resource = new BindingBehaviorResource(camelCase(impl.name));
+    } else if (!(resource instanceof BindingBehaviorResource)) {
+      throw new Error(`Resource defined at ${impl.name} is not a binding behavior.`);
+    }
+    resource.initialize(aurelia.container, impl);
+    resource.register(aurelia.resources);
+  }
+
+  valueConverter(impl: Function) {
+    const aurelia = this.aurelia;
+    let resource = metadata.getOwn(metadata.resource, impl);
+    if (!resource) {
+      resource = new ValueConverterResource(camelCase(impl.name));
+    } else if (!(resource instanceof ValueConverterResource)) {
+      throw new Error(`Resource defined at ${impl.name} is not a value converter.`);
+    }
+    resource.initialize(aurelia.container, impl);
+    resource.register(aurelia.resources);
   }
 }

--- a/test/framework-configuration.js
+++ b/test/framework-configuration.js
@@ -1,7 +1,9 @@
 import './setup';
-import {FrameworkConfiguration} from '../src/framework-configuration';
-import {Aurelia} from '../src/aurelia';
-import {Metadata} from 'aurelia-metadata';
+import { FrameworkConfiguration } from '../src/framework-configuration';
+import { Aurelia } from '../src/aurelia';
+// import {metadata} from 'aurelia-metadata'
+// import {ViewResources} from 'aurelia-templating'
+// import {Container} from 'aurelia-dependency-injection'
 
 describe('the framework config', () => {
   it('should initialize', () => {
@@ -37,13 +39,13 @@ describe('the framework config', () => {
       expect(mockContainer.registerSingleton).toHaveBeenCalledWith(TestClass, testInstance);
     });
 
-    it("globalResources will add an array of paths", () => {
+    it('globalResources will add an array of paths', () => {
       let resourceName = './someResource';
       expect(aurelia.use.globalResources([resourceName])).toBe(aurelia.use);
       expect(aurelia.use.resourcesToLoad[resourceName].moduleId).toEqual(resourceName);
     });
 
-    it("globalResources will add resources to lookup", () => {
+    it('globalResources will add resources to lookup', () => {
       expect(aurelia.use.globalResources('./someResource', './andAnother')).toBe(aurelia.use);
       expect('./someResource' in aurelia.use.resourcesToLoad).toEqual(true);
       expect('./andAnother' in aurelia.use.resourcesToLoad).toEqual(true);
@@ -58,15 +60,13 @@ describe('the framework config', () => {
 
       expect('plugin/someResource' in aurelia.use.resourcesToLoad).toEqual(true);
       expect(aurelia.use.resourcesToLoad['plugin/someResource'].relativeTo).toEqual('bootstrapper');
-
     });
-
   });
 
   describe('plugin()', () => {
     let configSpy,
-        loadModule,
-        config;
+      loadModule,
+      config;
 
     let aurelia, mockContainer, mockLoader, mockResources, mockPlugin, mockViewEngine;
 
@@ -74,7 +74,7 @@ describe('the framework config', () => {
       mockLoader = jasmine.createSpy('loader');
       mockResources = jasmine.createSpy('viewResources');
 
-      mockViewEngine = jasmine.createSpyObj("viewEngine", ["importViewResources"]);
+      mockViewEngine = jasmine.createSpyObj('viewEngine', ['importViewResources']);
       mockViewEngine.importViewResources.and.returnValue(new Promise((resolve, error) => {
         resolve();
       }));
@@ -86,11 +86,11 @@ describe('the framework config', () => {
       aurelia = new Aurelia(mockLoader, mockContainer, mockResources);
       config = aurelia.use;
 
-      configSpy = jasmine.createSpy("config");
+      configSpy = jasmine.createSpy('config');
 
       loadModule = jasmine.createSpy('loadModule').and.callFake((moduleId) => {
         return new Promise((resolve, reject) => {
-          if (moduleId === "plugin")
+          if (moduleId === 'plugin')
             resolve(configSpy);
           else
             reject("Couldn't find plugin");
@@ -101,7 +101,7 @@ describe('the framework config', () => {
       aurelia.loader.loadModule = loadModule;
     });
 
-    it("should default config to an empty object if not provided", () => {
+    it('should default config to an empty object if not provided', () => {
       config.plugin('noPlugin');
       expect(config.info.length).toBe(1);
 
@@ -122,23 +122,23 @@ describe('the framework config', () => {
       setTimeout(() => {
         expect(loadModule).not.toHaveBeenCalled();
         done();
-      })
+      });
     });
 
-    it("should load a plugin when processed", (done) => {
-      config.plugin("plugin").apply()
-        .then(() => expect(loadModule).toHaveBeenCalledWith("plugin"))
+    it('should load a plugin when processed', (done) => {
+      config.plugin('plugin').apply()
+        .then(() => expect(loadModule).toHaveBeenCalledWith('plugin'))
         .catch((reason) => expect(false).toBeTruthy(reason))
         .then(done);
     });
 
     it("should load a plugin and call its configure function if it's defined", (done) => {
       var pluginConfig = {};
-      configSpy.configure = jasmine.createSpy("configure").and.returnValue(null);
+      configSpy.configure = jasmine.createSpy('configure').and.returnValue(null);
 
-      config.plugin("plugin", pluginConfig).apply()
+      config.plugin('plugin', pluginConfig).apply()
         .then(() => {
-          expect(loadModule).toHaveBeenCalledWith("plugin");
+          expect(loadModule).toHaveBeenCalledWith('plugin');
           expect(configSpy.configure).toHaveBeenCalledWith(config, pluginConfig);
         })
         .catch((reason) => expect(false).toBeTruthy(reason))
@@ -148,14 +148,14 @@ describe('the framework config', () => {
     it("should load a plugin, call it's configure function and resolve the returned promise if defined", (done) => {
       var pluginConfig = {};
       var resolved = false;
-      configSpy.configure = jasmine.createSpy("configure").and.returnValue(new Promise((resolve) => {
+      configSpy.configure = jasmine.createSpy('configure').and.returnValue(new Promise((resolve) => {
         resolved = true;
         resolve();
       }));
 
-      config.plugin("plugin", pluginConfig).apply()
+      config.plugin('plugin', pluginConfig).apply()
         .then(() => {
-          expect(loadModule).toHaveBeenCalledWith("plugin");
+          expect(loadModule).toHaveBeenCalledWith('plugin');
           expect(configSpy.configure).toHaveBeenCalledWith(config, pluginConfig);
           expect(resolved).toBeTruthy();
         })
@@ -163,17 +163,17 @@ describe('the framework config', () => {
         .then(done);
     });
 
-    it("should reject if the plugin fails to load", (done) => {
-      config.plugin("failedLoad").apply()
-        .then(() => expect(true).toBeFalsy("This should have failed"))
-        .catch(() => expect(loadModule).toHaveBeenCalledWith("failedLoad"))
+    it('should reject if the plugin fails to load', (done) => {
+      config.plugin('failedLoad').apply()
+        .then(() => expect(true).toBeFalsy('This should have failed'))
+        .catch(() => expect(loadModule).toHaveBeenCalledWith('failedLoad'))
         .then(done);
     });
 
-    it("should throw if the plugin loader has been processed", (done) => {
+    it('should throw if the plugin loader has been processed', (done) => {
       config.apply().then(() => {
         expect(config.processed).toBeTruthy();
-        expect(() => config.plugin("plugin")).toThrow(new Error('This config instance has already been applied. To load more plugins or global resources, create a new FrameworkConfiguration instance.'));
+        expect(() => config.plugin('plugin')).toThrow(new Error('This config instance has already been applied. To load more plugins or global resources, create a new FrameworkConfiguration instance.'));
         done();
       });
     });
@@ -186,7 +186,7 @@ describe('the framework config', () => {
       mockLoader = jasmine.createSpy('loader');
       mockResources = jasmine.createSpy('viewResources');
 
-      mockViewEngine = jasmine.createSpyObj("viewEngine", ["importViewResources"]);
+      mockViewEngine = jasmine.createSpyObj('viewEngine', ['importViewResources']);
       mockViewEngine.importViewResources.and.returnValue(new Promise((resolve, error) => {
         resolve();
       }));
@@ -199,20 +199,43 @@ describe('the framework config', () => {
       aurelia = new Aurelia(mockLoader, mockContainer, mockResources);
     });
 
-    it("should load resources that are defined and register them with the resource registry", (done) => {
-      aurelia.use.resourcesToLoad["./aResource"] = {moduleId: './aResource', relativeTo: ''};
+    it('should load resources that are defined and register them with the resource registry', (done) => {
+      aurelia.use.resourcesToLoad['./aResource'] = {moduleId: './aResource', relativeTo: ''};
 
-      let resource = jasmine.createSpyObj("resource", ["register"]);
+      let resource = jasmine.createSpyObj('resource', ['register']);
 
       mockViewEngine.importViewResources.and.returnValue(new Promise((resolve, error) => {
         resolve([resource]);
       }));
 
       aurelia.start().then(() => {
-        expect(mockViewEngine.importViewResources).toHaveBeenCalledWith(["./aResource"], [undefined], mockResources);
+        expect(mockViewEngine.importViewResources).toHaveBeenCalledWith(['./aResource'], [undefined], mockResources);
       })
-      .catch((reason) => expect(true).toBeFalsy(reason))
-      .then(done);
+        .catch((reason) => expect(true).toBeFalsy(reason))
+        .then(done);
     });
   });
+
+  // fdescribe('synchronous registration', () => {
+  //   let aurelia, container, mockLoader
+  //   /** @type {ViewResources} */
+  //   let resources
+  //   /**@type {FrameworkConfiguration} */
+  //   let config
+
+  //   beforeEach(() => {
+  //     mockLoader = jasmine.createSpy('loader')
+  //     resources = new ViewResources()
+  //     container = new Container()
+
+  //     mockLoader.normalize = jasmine.createSpy('normalize').and.callFake(input => Promise.resolve(input))
+  //     aurelia = new Aurelia(mockLoader, container, resources)
+  //     config = new FrameworkConfiguration(aurelia)
+  //   })
+
+//   it('register custom element', () => {
+//     config.customElement(class Abc {})
+//     expect(resources.getElement('abc')).toBeTruthy()
+//   })
+// })
 });


### PR DESCRIPTION
At the moment, Aurelia only absorbs global resource declarations via modules loading, which also enables all sorts of lazy loading: component level, router level, but there is no convenient way to load resources directly (or synchronously) via implementation (classes). This PR enables that scenario, which should also help bundler bundle Aurelia application more effectively.

4 new APIs added to `FrameworkConfiguration`:

  * `customElement(implementation: Function): void`
  * `customAttribute(implementation: Function): void`
  * `bindingBehavior(implementation: Function): void`
  * `valueConverter(implementation: Function): void`


**Examples**:

  #### Current way

  ```js
  /**
   * @param {FrameworkConfiguration} config
   */
  export function configure(config) {
    config.globalResources(
      './my-module',
      './my-resources'
    );
  }
  ```

  #### new way

  ```js
  import { MyElement, MyAttribute } from './my-module';
  import { MyBindingBehavior, MyValueConverter } from './my-resources'

  /**
   * @param {FrameworkConfiguration} config
   */
  export function configure(config) {
    config.customElement(MyElement);
    config.customAttribute(MyAttribute);
    config.bindingBehavior(MyBindingBehavior);
    config.valueConverter(MyValueConverter);
  }
  ```

How this helps: we see that classes / implementations are used directly and thus, should be more friendly with bundlers. An example would be tree shaking: if we are to use module name via string, there would be no way to tree shake an unused resources, but if we are to use classes, it would be possible. Following example is how `aurelia-templating-resources` would look like if this was supported:

#### Current way

```js
  function configure(config) {
  injectAureliaHideStyleAtHead();

  config.globalResources(
    PLATFORM.moduleName('./compose'),
    PLATFORM.moduleName('./if'),
    PLATFORM.moduleName('./else'),
    // ...
  );

  // ....

}
```

#### New way

```js
import { Compose } from './compose'
import { If } from './if'
import { Else } from './else'

function configure(config) {
  injectAureliaHideStyleAtHead();

  config.customElement(Compose);
  config.customAttribute(If);
  config.customAttribute(Else);

  // ...
}
```

So it can be tree shake via environment variables, with the help of minifiers like the following examples:

#### New way + environment variables + tree shaking

```js
import { Compose } from './compose'
import { If } from './if'
import { Else } from './else'

function configure(config) {
  injectAureliaHideStyleAtHead();

  if (typeof AU_NO_COMPOSE === 'undefined') {
    config.customElement(Compose);
  }
  if (typeof AU_NO_IF === 'undefined') {
    config.customAttribute(If);
    config.customAttribute(Else);
  }
  
  // ...
}
```

And then in bundlers, we can easily shake default resources via defining the environment variables. For example, say we know our application won't use compose, just need to do like following in webpack configuration:

```js
  new webpack.DefinePlugin({
    AU_NO_COMPOSE: true
  });
```

With this enabled, we can offer more out of the box binding behaviors/ value converters with fool proof tree shaking configuration and bundle size will never go off the roof.

---

#### Caveats:

  * Loading custom elements won't be easy because this breaks the convention: view url has to be either specified explicitly or import & inlined into view model classes. However, this could be easier once we introduce single file component.
  * Only works for global resources

-----

### Summary:

**pros**
  * Bundler friendlier
  * Tree shake-able resources
  * perf (as they are all synchronous declaration), no need for creating promiose to load many resources, and modules can be easily concatenated (scope hoisting)

**cons**
  * Convention of view finding based on view model is not applicable.
  * ??

----

### API

The api could be improved, so it doens't have to be too tedious:

From:

```js
  config.customElement(A);
  config.customElement(B);
  // ...
```

To:

```js
  config.global({
    customElements: [A, B, C],
    customAttributes: [D, E, F],
    bindingBehaviors: [I, J, K],
    valueConverters: [X, Y, Z]
  });
```

----

### [Update 1:](#update-1)

I have overloaded the method `globalResources`. Now it can take either string as module name, class (function) as implementation or one object for explicit configuration. Example:

  1. Explicit

  ```js
  // Note that class names are treated as is when using this overload
  config.globalResources({
    customElements: [Compose],
    customAttributes: [If],
    bindingBehaviors: [Self], // <=== SelfBindingBehavior will not be converted to self
    valueConverters: [SanitizeHTML] // <=== SanitizeHTMLValueConverter will not be converted
  })
  ```

  2. Implicit, via implementation

  ```js
  config.globalResources(
    If,  // <-- will rely on customAttribute('if') call
    Else,
    // ....
    Compose, // <-- will rely on customElement('compose') call
    SelfBindingBehavior, // <-- will be converted based on convention
    OneTimeBindingBehavior, // <-- will be converted based on convention
    // ....
    SanitizeHTMLValueConverter // <-- will be converted based on convention
  );
  ```

  3. Mixed
  ```js
  config.globalResources(
    If,  // <-- will rely on customAttribute('if') call
    PLATFORM.moduleName('./else'), // <-- like the old way
    // ....
  );
  ```

It needs to be mentioned explicitly somewhere in the doc that loading resources via module name string will always come after the loading resources via implementation, as one is loaded during **POST** task, and the other is loaded during **PLUGIN(MAIN)** task

----

### [Update 2: Some details for discussion](#update-2)

  - Should resources be loaded in order ? Which means, either loading resources via string as module name or directly as implementation will have their order respected. This requires changes in `ViewEngine.importViewResources`:
  ```js
    config.globalResources(
      './my-module',
      // Should it respect the order and only load MyClass
      // after all resources in my modules have been loaded ?
      MyClass, 
    )
  ```
  How resources are loaded currently with the new API: synchronous resources will be loaded first, if it is a custom element, its view will be loaded after all resources that is loaded via module name have been loaded..
  
  - Named export in webpack is normally not mangled, but class name will be (I think this is configurable, but on new version only). How should we document this, as `MyBindingBehavior` class will not be registered as `my` binding behavior when building for production using the new API.
  