### PR TITLE
Updated dependencies for aurelia-binding (removed 1.x dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "dist": "dist/amd"
     },
     "peerDependencies": {
-      "aurelia-binding": "^1.0.0 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-loader": "^1.0.0",
       "aurelia-logging": "^1.0.0",
@@ -39,7 +39,7 @@
       "aurelia-templating": "^1.8.0-rc.1"
     },
     "dependencies": {
-      "aurelia-binding": "^1.0.0 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-loader": "^1.0.0",
       "aurelia-logging": "^1.0.0",
@@ -57,7 +57,7 @@
     }
   },
   "dependencies": {
-    "aurelia-binding": "^1.0.0 || ^2.0.0",
+    "aurelia-binding": "^2.0.0",
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-loader": "^1.0.0",
     "aurelia-logging": "^1.0.0",


### PR DESCRIPTION
To be able to install via JSPM (which doesn't support comparator sets for versioning)

Fixes #895.

Note; got 1 failing specs test when running `karma start`:

> WARN [karma]: No captured browser, open http://localhost:9876/
> INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
> INFO [launcher]: Launching browser Chrome with unlimited concurrency
> INFO [launcher]: Starting browser Chrome
> INFO [Chrome 67.0.3396 (Windows 10.0.0)]: Connected on socket 7yMa3-xOliKE8IMbAAAA with id 94643261
> Chrome 67.0.3396 (Windows 10.0.0) aurelia setRoot() should accept view model class as root FAILED
>         Expected Function to be Function.
>             at eval (test/aurelia.spec.js:264:52)
>             at tryCatchReject (jspm_packages/system-polyfills.src.js:1188:30)
>             at runContinuation1 (jspm_packages/system-polyfills.src.js:1147:4)
>             at Fulfilled.when (jspm_packages/system-polyfills.src.js:935:4)
> Chrome 67.0.3396 (Windows 10.0.0): Executed 35 of 35 (1 FAILED) (0.146 secs / 0.09 secs)

... but I'm not sure if this is related to the updated dependency versions