### PR TITLE
Remove unneeded bootstrap require in app.html

### DIFF
--- a/doc/article/en-US/contact-manager-tutorial.md
+++ b/doc/article/en-US/contact-manager-tutorial.md
@@ -1063,7 +1063,6 @@ Ok, now that we've got an `api` property we can bind to, update your `app.html` 
 <code-listing heading="app.html">
   <source-code lang="HTML">
     <template>
-      <require from="bootstrap/css/bootstrap.css"></require>
       <require from="./styles.css"></require>
       <require from="./contact-list"></require>
 


### PR DESCRIPTION
We're already including bootstrap in the main file, also the line causes a compilation error when working with Typescript and Bootstrap 4.1.1