### PR TITLE
(doc): change to readme to include getting started details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,56 @@
 # Contributing
 
-We'd love for you to contribute and to make this project even better than it is today! If this interests you, please begin by reading [our contributing guidelines](https://github.com/DurandalProject/about/blob/master/CONTRIBUTING.md). The contributing document will provide you with all the information you need to get started. Once you have read that, you will need to also [sign our CLA](http://goo.gl/forms/dI8QDDSyKR) before we can accept a Pull Request from you. More information on the process is included in the [contributor's guide](https://github.com/DurandalProject/about/blob/master/CONTRIBUTING.md).
+Please begin by reading [our contributing guidelines](https://github.com/DurandalProject/about/blob/master/CONTRIBUTING.md). The contributing document will provide you with all the information you need to get started. Once you have read that, you will need to also [sign our CLA](http://goo.gl/forms/dI8QDDSyKR) before we can accept a Pull Request from you. More information on the process is included in the [contributor's guide](https://github.com/DurandalProject/about/blob/master/CONTRIBUTING.md).
+
+# Getting started
+Ready to get started? The below sections take you through the steps required to get the framework running on your local development environment, and run the associated tests.
+
+## Building The Code
+
+To build the code, follow these steps.
+
+1. Ensure that [NodeJS](http://nodejs.org/) is installed. This provides the platform on which the build tooling runs.
+2. From the project folder, execute the following command:
+
+  ```shell
+  npm install
+  ```
+3. Ensure that [Gulp](http://gulpjs.com/) is installed. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g gulp
+  ```
+4. To build the code, you can now run:
+
+  ```shell
+  gulp build
+  ```
+5. You will find the compiled code in the `dist` folder, available in three module formats: AMD, CommonJS and ES6.
+
+6. See `gulpfile.js` for other tasks related to generating the docs and linting.
+
+## Running The Tests
+
+To run the unit tests, first ensure that you have followed the steps above in order to install all dependencies and successfully build the library. Once you have done that, proceed with these additional steps:
+
+1. Ensure that the [Karma](http://karma-runner.github.io/) CLI is installed. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g karma-cli
+  ```
+2. Ensure that [jspm](http://jspm.io/) is installed. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g jspm
+  ```
+3. Install the client-side dependencies with jspm:
+
+  ```shell
+  jspm install
+  ```
+
+4. You can now run the tests with this command:
+
+  ```shell
+  karma start
+  ```

--- a/README.md
+++ b/README.md
@@ -1,68 +1,72 @@
-# aurelia-framework
+<div align="center" style="display:flex; justify-content:center">
+  <a href="https://aurelia.io" target="_blank" rel="noopener noreferrer">
+    <img width="100" src="https://aurelia.io/styles/images/aurelia-icon.svg" alt="Aurelia logo">
+  </a>
+</div>
 
-[![npm Version](https://img.shields.io/npm/v/aurelia-framework.svg)](https://www.npmjs.com/package/aurelia-framework)
-[![ZenHub](https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)](https://zenhub.io)
-[![Join the chat at https://gitter.im/aurelia/discuss](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aurelia/discuss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![CircleCI](https://circleci.com/gh/aurelia/framework.svg?style=shield)](https://circleci.com/gh/aurelia/framework)
+<div align="center">
 
-This library is part of the [Aurelia](http://www.aurelia.io/) platform and contains the aurelia framework which brings together all the required core aurelia libraries into a ready-to-go application-building platform.
+  [![npm Version](https://img.shields.io/npm/v/aurelia-framework.svg)](https://www.npmjs.com/package/aurelia-framework)
+  [![ZenHub](https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)](https://zenhub.io)
+  [![Join the chat at https://gitter.im/aurelia/discuss](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aurelia/discuss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+  [![CircleCI](https://circleci.com/gh/aurelia/framework.svg?style=shield)](https://circleci.com/gh/aurelia/framework)
 
-> To keep up to date on [Aurelia](http://www.aurelia.io/), please visit and subscribe to [the official blog](http://blog.aurelia.io/) and [our email list](http://eepurl.com/ces50j). We also invite you to [follow us on twitter](https://twitter.com/aureliaeffect). If you have questions look around our [Discourse forums](https://discourse.aurelia.io/), chat in our [community on Gitter](https://gitter.im/aurelia/discuss) or use [stack overflow](http://stackoverflow.com/search?q=aurelia). Documentation can be found [in our developer hub](http://aurelia.io/docs). If you would like to have deeper insight into our development process, please install the [ZenHub](https://zenhub.io) Chrome or Firefox Extension and visit any of our repository's boards.
+</div>
 
-## Documentation
+<h1 align="center" style="color:#6d50a2">aurelia-framework</h1>
 
-You can read the documentation for the aurelia framework [here](http://aurelia.io/docs). If you would like to help improve this documentation, the source for many of the docs can be found in the doc folder within this repository. Other docs, not related to the general framework, but directed at specific libraries, can be found in the doc folder of those libraries.
+Aurelia is a modern front-end JavaScript framework for building browser, mobile and desktop applications.
 
-## Platform Support
+This library is part of the [Aurelia](http://www.aurelia.io/) platform. It contains the aurelia framework which brings together all the required core aurelia libraries into a ready-to-go application-building platform.
 
-This library can be used in the **browser** only.
+Aurelia applications are built by composing a series of simple components. By convention components are made up of a vanilla JavaScript or Typescript class, with a corresponding HTML template. 
 
-## Building The Code
+```js
+//app.js
+export class App {
+  message = 'Hello World!';
+}
+```
 
-To build the code, follow these steps.
+```html
+<!-- app.html -->
+<template>
+  <h1>${message}</h1>
+</template>
 
-1. Ensure that [NodeJS](http://nodejs.org/) is installed. This provides the platform on which the build tooling runs.
-2. From the project folder, execute the following command:
+```
+>Check out the interactive version of this example at [Code Sandbox](https://codesandbox.io/s/849oxmjm82).
 
-  ```shell
-  npm install
-  ```
-3. Ensure that [Gulp](http://gulpjs.com/) is installed. If you need to install it, use the following command:
+As you may have guessed, this will render `Hello World!`  into the `<h1>` element on the page. This is just a basic example of how you can use Aurelia's simple, declaritive binding syntax to render a value from your backing view-model to your view, but of course you can do much more! To see further examples, online playgrounds, guides, and detailed API documentation. Head on over to [aurelia.io](https://aurelia.io).
 
-  ```shell
-  npm install -g gulp
-  ```
-4. To build the code, you can now run:
 
-  ```shell
-  gulp build
-  ```
-5. You will find the compiled code in the `dist` folder, available in three module formats: AMD, CommonJS and ES6.
+# Documentation
 
-6. See `gulpfile.js` for other tasks related to generating the docs and linting.
+You can read the documentation for the aurelia framework [here](http://aurelia.io/docs). It's divided into the following sections:
 
-## Running The Tests
+* [Overview](https://aurelia.io/docs/) : Discover what Aurelia is along with its business and technical advantages.
+* [Tutorials](https://aurelia.io/docs/tutorials) : Step-by-step tutorials teaching you how to build your first Aurelia applications.
+* [Fundamentals](https://aurelia.io/docs/) : After you've completed the quick starts, learn more about Aurelia's app model, components, dependency injection and more.
+* [Binding](https://aurelia.io/docs/binding): Learn all about Aurelia's powerful data-binding engine.
+* [Templating](https://aurelia.io/docs/binding): Learn all about Aurelia's powerful templating engine.
+* [Routing](https://aurelia.io/docs/routing): Learn how to setup and configure Aurelia's router.
+* [Plugins](https://aurelia.io/docs/plugins): Learn about Aurelia's officially supported plugins and how to use them.
+* [Integration](https://aurelia.io/docs/integration): Learn how to integrate Aurelia with various other libraries and frameworks.
+* [Testing](https://aurelia.io/docs/testing): Learn all about testing Aurelia apps, including component testing and e2e testing.
+* [Server Side Rendering](https://aurelia.io/docs/ssr): Learn about Server Side Rendering with Aurelia and how to configure your project.
+* [CLI](https://aurelia.io/docs/cli): Learn how to create, build, bundle and test your apps using all your favorite tools, facilitated by the Aurelia CLI.
+* [Build Systems](https://aurelia.io/docs/build-systems): Various systems for building and bundling Aurelia apps.
+  
+>You can improve the documentation by contributing to [this repository](https://github.com/aurelia/documentation).
 
-To run the unit tests, first ensure that you have followed the steps above in order to install all dependencies and successfully build the library. Once you have done that, proceed with these additional steps:
+# Staying up to date
+To keep up to date on [Aurelia](http://www.aurelia.io/), please visit and subscribe to [the official blog](http://blog.aurelia.io/) and [our email list](http://eepurl.com/ces50j). We also invite you to [follow us on twitter](https://twitter.com/aureliaeffect).  If you would like to have deeper insight into our development process, please install the [ZenHub](https://zenhub.io) Chrome or Firefox Extension and visit any of our repository's boards.
 
-1. Ensure that the [Karma](http://karma-runner.github.io/) CLI is installed. If you need to install it, use the following command:
+# Questions
+If you have questions look around our [Discourse forums](https://discourse.aurelia.io/), chat in our [community on Gitter](https://gitter.im/aurelia/discuss) or use [stack overflow](http://stackoverflow.com/search?q=aurelia).
 
-  ```shell
-  npm install -g karma-cli
-  ```
-2. Ensure that [jspm](http://jspm.io/) is installed. If you need to install it, use the following command:
+# Contributing
+We'd love for you to contribute and to make this project even better than it is today! You can start by checking out our [contributing guide](CONTRIBUTING.md), which has everything you need to get up and running.
 
-  ```shell
-  npm install -g jspm
-  ```
-3. Install the client-side dependencies with jspm:
-
-  ```shell
-  jspm install
-  ```
-
-4. You can now run the tests with this command:
-
-  ```shell
-  karma start
-  ```
+# License 
+Aurelia is MIT licensed. You can find out more and read the license document [here](LICENSE).


### PR DESCRIPTION
change to readme document to include simple getting started example, links to documentation, and re-organisation of contributing details

first step towards addressing issue #318