### PR TITLE
Add follow on twitter badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![npm Version](https://img.shields.io/npm/v/aurelia-framework.svg)](https://www.npmjs.com/package/aurelia-framework)
 [![CircleCI](https://circleci.com/gh/aurelia/framework.svg?style=shield)](https://circleci.com/gh/aurelia/framework)
 [![Discourse status](https://img.shields.io/discourse/https/meta.discourse.org/status.svg)](https://discourse.aurelia.io)
+[![Twitter](https://img.shields.io/twitter/follow/aureliaeffect.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=aureliaeffect)
 
 # aurelia-framework
 


### PR DESCRIPTION
I think it's a good idea to have a `follow on twitter` badge as part of the docs 🤔 
> It looks like this:

[![Twitter](https://img.shields.io/twitter/follow/aureliaeffect.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=aureliaeffect)