### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/framework-configuration.js
+++ b/src/framework-configuration.js
@@ -258,7 +258,7 @@ export class FrameworkConfiguration {
     case 'string':
       let hasIndex = /\/index$/i.test(plugin);
       let moduleId = hasIndex || getExt(plugin) ? plugin : plugin + '/index';
-      let root = hasIndex ? plugin.substr(0, plugin.length - 6) : plugin;
+      let root = hasIndex ? plugin.slice(0, -6) : plugin;
       this.info.push({ moduleId, resourcesRelativeTo: [root, ''], config });
       break;
       // return this.plugin({ moduleId, resourcesRelativeTo: [root, ''], config });


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.