### PR TITLE
folder dist/types no longer exists so changing to just dist

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,4 +1,4 @@
 {
   "name": "aurelia-framework",
-  "main": "dist/types/aurelia-framework.d.ts"
+  "main": "dist/aurelia-framework.d.ts"
 }


### PR DESCRIPTION
I may be missing something but I get a 404 as dist/types/aurelia-framework.d.ts does not exist, and looking at refactored code looks like the location is now dist/aurelia-framework.d.ts